### PR TITLE
Fix ZSH error when using symlink from _SUB_ROOT/sub instead of bin/sub

### DIFF
--- a/libexec/sub
+++ b/libexec/sub
@@ -19,7 +19,7 @@ abs_dirname() {
   cd "$cwd"
 }
 
-libexec_path="$(abs_dirname "$0")"
+libexec_path="$(abs_dirname ./"$0")"
 export _SUB_ROOT="$(abs_dirname "$libexec_path")"
 export PATH="${libexec_path}:$PATH"
 


### PR DESCRIPTION
I confirmed that this works with both bash and zsh.

[refs #23]
