### PR TITLE
Exec libexec/sub from bin/sub instead of symlinking

### DIFF
--- a/bin/sub
+++ b/bin/sub
@@ -1,1 +1,2 @@
-../libexec/sub
+#!/usr/bin/env ruby
+exec("/bin/sh", "#{File.dirname(__FILE__)}/../libexec/sub", *ARGV)


### PR DESCRIPTION
While trying to provide a tool built with sub as a gem, I learned that symlinks aren't maintained while building gems. This meant that `bin/sub` would be flattened into a copy of `libexec/sub` rather than remaining a symlink. This was problematic because [the bin file within a gem must be a ruby script](http://guides.rubygems.org/specification-reference/#executables).

This change execs `libexec/sub` instead of symlinking, which removes a roadblock when gemifying sub projects.
