### PR TITLE
Improve install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,9 @@ So you've prepared your own sub, now how do you use it? Here's one way you could
 
     cd
     git clone [YOUR GIT HOST URL]/sub.git .sub
+    .sub/bin/sub init
 
-For bash users:
-
-    echo 'eval "$($HOME/.sub/bin/sub init -)"' >> ~/.bash_profile
-    exec bash
-
-For zsh users:
-
-    echo 'eval "$($HOME/.sub/bin/sub init -)"' >> ~/.zshenv
-    source ~/.zshenv
+Then follow the instructions given by `sub init` to add `sub` to your path and set up autocompletions.
 
 You could also install your sub in a different directory, say `/usr/local`. This is just one way you could provide a way to install your sub.
 

--- a/libexec/sub-help
+++ b/libexec/sub-help
@@ -33,10 +33,16 @@ print_summaries() {
 }
 
 print_help() {
-  local file="$1"
+  local command="$1"
+  local file="$2"
   local usage="$(usage "$file")"
 
   if [ -n "$usage" ]; then
+    if [ -L "$file" ]; then
+      local target_command="$(readlink $file | sed -r 's/^sub-(sh-)?//')"
+      echo "$command is an alias for the command $target_command". && echo
+    fi
+    
     echo "$usage"
 
     local help="$(help "$file")"
@@ -93,7 +99,7 @@ See 'sub help <command>' for information on a specific command."
   file="$(command_path "$command")"
 
   if [ -n "$file" ]; then
-    print_help "$file"
+    print_help "$command" "$file"
   else
     echo "sub: no such command \`$command'" >&2
     exit 1

--- a/libexec/sub-init
+++ b/libexec/sub-init
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Usage: sub init [-]
+# Summary: Install sub
+# Help: When called without any option, this will print instructions on how to install sub.
+# If invoked with the - option, you get a few lines of shell script that will, when eval'd, set up sub for your current session.
 set -e
 
 print=""


### PR DESCRIPTION
My primary motivation with this was to add documentation for the `init` command. After I did that, I thought the installation instructions in `README.md` were a little bit redundant, so I changed them to just reference to the output of the `init` command. This seems cleaner as well as clearer from a UX viewpoint to me.